### PR TITLE
Fix link to customize workflow page

### DIFF
--- a/src/content/docs/getting-started/run-a-workflow.md
+++ b/src/content/docs/getting-started/run-a-workflow.md
@@ -1,6 +1,6 @@
 ---
 title: Run a Workflow
-description: 
+description:
   Now that the Everywhere Computer is running on your machine, let's run a
   workflow.
 sidebar:
@@ -26,4 +26,4 @@ Once you have hit `Run`, you should see the workflow in `Running...` mode.
 
 Shortly, your first workflow run should be `complete`. And you should be able to view the output: a cropped and blurred version of your original input image.
 
-Painless, right? Now let's work on [customizing that workflow](customize-a-workflow).
+Painless, right? Now let's work on [customizing that workflow](../customize-a-workflow).


### PR DESCRIPTION
This PR fixes a broken link to the `customize-a-workflow` page. 

Without traversing up one level, the link appends `customize-a-workflow` to the current URL linking to https://docs.everywhere.computer/getting-started/run-a-workflow/customize-a-workflow instead of https://docs.everywhere.computer/getting-started/customize-a-workflow/.