### PR TITLE
Fix broken link to configuration page

### DIFF
--- a/src/content/docs/homestar/using-homestar.md
+++ b/src/content/docs/homestar/using-homestar.md
@@ -55,7 +55,7 @@ The runtime can be provided a configuration file and an SQLite database file. Ho
 homestar start -c settings.toml --db my.db
 ```
 
-See our [configuration guide](configuration) for information about node configuration.
+See our [configuration guide](../configuration) for information about node configuration.
 
 ## Ping
 


### PR DESCRIPTION
Fixes a broken link from the Using Homestar page to the Homestar Configuration page.