### PR TITLE
Add Homestar 0.3.0 updates

### DIFF
--- a/src/content/docs/homestar/configuration.md
+++ b/src/content/docs/homestar/configuration.md
@@ -5,7 +5,7 @@ description: Configuring a Homestar node
 
 Homestar nodes are configured with a [TOML](https://toml.io) settings file. Homestar logs its configuration at start up.
 
-We maintain a [defaults.toml](https://github.com/ipvm-wg/homestar/blob/main/homestar-runtime/config/defaults.toml) configuration file than includes all default Homestar settings.
+Run `homestar init --dry-run` to view the default Homestar settings.
 
 ## Minimal configuration
 

--- a/src/content/docs/homestar/using-homestar.md
+++ b/src/content/docs/homestar/using-homestar.md
@@ -18,6 +18,7 @@ $ homestar --help
 Usage: homestar <COMMAND>
 
 Commands:
+  init   Initialize a Homestar configuration
   start  Start the Homestar runtime
   stop   Stop the Homestar runtime
   ping   Ping the Homestar runtime to see if it's running
@@ -29,6 +30,51 @@ Commands:
 Options:
   -h, --help     Print help
   -V, --version  Print version
+```
+
+## Initialize
+
+The `homestar init` command generates a Homestar settings file and optionally key material. Use the `--key-seed` or `--key-file` options to use existing key material.
+
+Settings and key material are written to `~/.config/homestar` by default, but the output location can be overriden with the `--output` option.
+
+```
+$ homestar init --help
+Initialize a Homestar configuration
+
+Usage: homestar init [OPTIONS]
+
+Options:
+  -o, --output <OUTPUT>
+          Path to write initialized configuration file (.toml) [optional]
+
+      --dry-run
+          Skip writing to disk, instead writing configuration to stdout [optional]
+
+  -q, --quiet
+          Suppress auxiliary output [optional]
+
+  -f, --force
+          Force destructive operations without prompting [optional]
+
+      --no-input
+          Run in non-interactive mode [optional]
+
+      --key-type <KEY_TYPE>
+          The type of key to use for libp2p [optional]
+
+          Possible values:
+          - ed25519:   Ed25519 key
+          - secp256k1: Secp256k1 key
+
+      --key-file [<KEY_FILE>]
+          The path to the key file. A key will be generated if the file does not exist, and if left unspecified, a default path will be used. [optional]
+
+      --key-seed [<KEY_SEED>]
+          The seed to use for generating the key. If left unspecified, a random seed will be chosen [optional]
+
+  -h, --help
+          Print help (see a summary with '-h')
 ```
 
 ## Start the runtime


### PR DESCRIPTION
This PR updates the Homestar docs for Homestar version 0.3.0.

The changes include:

- [x] Add `homestar init` command
- [x] Update instructions for displaying default settings